### PR TITLE
minor typo fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In the Julia REPL run  `]add https://github.com/alan-turing-institute/MLJ.jl.git
 using MLJ
 
 X, y = datanow(); # boston dataset
-train, test = partition(eachindex(y), 0.5); # 70:30 split
+train, test = partition(eachindex(y), 0.7); # 70:30 split
 ```
 
 A *model* is a container for hyperparameters:

--- a/doc/tiny_demo.ipynb
+++ b/doc/tiny_demo.ipynb
@@ -44,7 +44,7 @@
     "using MLJ\n",
     "\n",
     "X, y = datanow(); # load the Boston dataset\n",
-    "train, test = partition(eachindex(y), 0.5); # 70:30 split"
+    "train, test = partition(eachindex(y), 0.7); # 70:30 split"
    ]
   },
   {


### PR DESCRIPTION
in partition, should be 0.7 for a 70:30 split. 

(it changes the RMS for subsequent results quoted, though there's randomness anyway so it doesn't matter too much I guess)