### PR TITLE
updated install guide (MLJBase first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Julia 0.7
 
 ### Installation
 
-In the Julia REPL run  `]add https://github.com/alan-turing-institute/MLJ.jl.git`
+In the Julia REPL run `]add https://github.com/alan-turing-institute/MLJBase.jl` first and `]add https://github.com/alan-turing-institute/MLJ.jl.git` afterwards.
 
 
 ### Basic train and test


### PR DESCRIPTION
error if install according to old version:
```julia
ERROR: Unsatisfiable requirements detected for package MLJBase [a7f614a8]:
 MLJBase [a7f614a8] log:
 ├─MLJBase [a7f614a8] has no known versions!
 └─restricted to versions * by MLJ [add582a8] — no versions left
   └─MLJ [add582a8] log:
     ├─possible versions are: 0.1.0 or uninstalled
     └─MLJ [add582a8] is fixed to version 0.1.0
```