### PR TITLE
fix for the clean! method of kmeans

### DIFF
--- a/src/interfaces/Clustering.jl
+++ b/src/interfaces/Clustering.jl
@@ -33,9 +33,9 @@ end
 
 function MLJBase.clean!(model::Union{KMeans, KMedoids})
     warning = ""
-    if model.k < 1
-        warning *= "Need k > 1. Resetting k=1.\n"
-        model.k = 1
+    if model.k < 2
+        warning *= "Need k >= 2. Resetting k=2.\n"
+        model.k = 2
     end
     return warning
 end


### PR DESCRIPTION
`k`,  should be at least equal to 2 and not `1`, mixup with knn. (see also https://github.com/JuliaStats/Clustering.jl/blob/master/src/kmeans.jl#L31).