### PR TITLE
Fix tests about Union{Missing, ...}

### DIFF
--- a/test/tasks.jl
+++ b/test/tasks.jl
@@ -86,11 +86,11 @@ end == 0
     @test ismissing(y_coerced == [4, 7, missing])
     @test scitype_union(y_coerced) === Union{Missing,Count}
     @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
-                                   coerce(Multiclass, [:x, :y, missing]))) <:
-        Union{Missing, Multiclass}
+                                   coerce(Multiclass, [:x, :y, missing]))) ===
+        Union{Missing, Multiclass{2}}
     @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
-                                   coerce(FiniteOrderedFactor, [:x, :y, missing]))) <:
-        Union{Missing, FiniteOrderedFactor}
+                                   coerce(FiniteOrderedFactor, [:x, :y, missing]))) ===
+                                       Union{Missing, FiniteOrderedFactor{2}}
     # non-missing Any vectors
     @test coerce(Continuous, Any[4, 7]) == [4.0, 7.0]
     @test coerce(Count, Any[4.0, 7.0]) == [4, 7]
@@ -99,10 +99,10 @@ end
 # task constructors:
 df = (x=10:10:44, y=1:4, z=collect("abcd"), w=[1.0, 3.0, missing])
 types = Dict(:x => Continuous, :z => Multiclass, :w => Count)
-task = supervised(data=df, types=types, target=:y, ignore=:y,
-                  is_probabilistic=false)
+task = @test_logs((:warn, r"Missing values encountered"), (:info, r"\n"),
+                  supervised(data=df, types=types, target=:y, ignore=:y, is_probabilistic=false))
 @test scitype_union(task.X.x) <: Continuous
-@test scitype_union(task.X.w) <: Union{Count, Missing}
+@test scitype_union(task.X.w) === Union{Count, Missing}
 @test scitype_union(task.y) <: Count
 
 end # module


### PR DESCRIPTION
The operator `<:` effectively acts like a subset operator, hence
```julia
julia> Count <: Union{Missing, Count}
true
```
For this reason, testing something like `scitype_union(x) <: Union{Count, Missing}` would fail to catch the case in which the missing values are lost somehow.

I [did this](https://github.com/giordano/MLJ.jl/commit/4f2e916c6c52d6fbe20f4a158962b3412cbf1524#diff-c2e14b5f3722eef92f44eecba69b7cd8) for the `Continuous` and `Count` case, but forgot to use the same test for discrete case.