### PR TITLE
Send code coverage to Coveralls and Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-
 ## Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 os:
@@ -19,6 +18,9 @@ matrix:
   allow_failures:
   - julia: nightly
 
+after_success:
+ - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'
+
 ## uncomment following lines to deploy documentation
 jobs:
   include:
@@ -35,4 +37,3 @@ jobs:
             Pkg.instantiate()
             include("docs/make.jl")
           '
-after_success: skip


### PR DESCRIPTION
Could someone please add `MLJ` (and also `MLJBase` and `MLJModels`, if possible) to [Coveralls](https://coveralls.io/repos/new)?  I don't have the rights to do that, I have no idea what I'd require.

I activated Coveralls on my fork, currently coverage of `MLJ` is at 71%, which is not bad!  https://coveralls.io/github/giordano/MLJ.jl