### PR TITLE
Move docs dependencies to Project.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
         - |
           julia --color=yes --project=docs/ -e'
             using Pkg
-            Pkg.add(PackageSpec(name="RDatasets"));Pkg.add(PackageSpec(name="Documenter"));Pkg.add(PackageSpec(name="DecisionTree"));Pkg.add(PackageSpec(name="DataFrames"));Pkg.add(PackageSpec(name="MLJBase", rev="master"));Pkg.add(PackageSpec(name="MLJ", rev="master"));Pkg.add(PackageSpec(name="MLJModels", rev="master"));Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.add(PackageSpec(name="MLJBase", rev="master"));Pkg.add(PackageSpec(name="MLJModels", rev="master"));Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()
             include("docs/make.jl")
           '

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,10 @@
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
+RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 
 [compat]
 Documenter = "~0.22"


### PR DESCRIPTION
I'd argue that we should not be using `master` for `MLJBase` and `MLJModels`: to keep a clean relation between all the package, we should always be using tagged versions (raising minimum required version in top-level `Project.toml`, if necessary).  The new package registration process is quite fast, so this shouldn't be a big deal.