### PR TITLE
Make CSV a test dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,15 +24,18 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+CSV = "0.5"
 MLJBase = "0.2.6"
 MLJModels = "0.2.0"
 julia = "1"
 
 [extras]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["DecisionTree", "RDatasets", "Test", "UnicodePlots"]
+test = ["CSV", "DecisionTree", "MLJBase", "RDatasets", "Test", "UnicodePlots"]

--- a/test/Transformers.jl
+++ b/test/Transformers.jl
@@ -1,7 +1,9 @@
 module TestTransformer
 
 # using Revise
-using MLJ, MLJBase
+using MLJ
+using MLJBase
+using CSV
 using Test
 using Statistics
 using DataFrames

--- a/test/datasets.jl
+++ b/test/datasets.jl
@@ -2,6 +2,8 @@ module TestDatasets
 
 # using Revise
 using MLJ
+using MLJBase
+using CSV
 
 load_ames()
 load_boston()

--- a/test/ensembles.jl
+++ b/test/ensembles.jl
@@ -10,7 +10,8 @@ module TestEnsembles
 using Test
 using Random
 using MLJ
-import MLJBase
+using MLJBase
+using CSV
 using CategoricalArrays
 using Distributions
 

--- a/test/machines.jl
+++ b/test/machines.jl
@@ -2,7 +2,8 @@ module TestMachines
 
 # using Revise
 using MLJ
-import MLJBase
+using MLJBase
+using CSV
 using Test
 using Statistics
 

--- a/test/networks.jl
+++ b/test/networks.jl
@@ -3,7 +3,8 @@ module TestLearningNetworks
 # using Revise
 using Test
 using MLJ
-import MLJBase
+using MLJBase
+using CSV
 using CategoricalArrays
 
 # TRAINABLE MODELS

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -4,6 +4,7 @@ module TestResampling
 using Test
 using MLJ
 using MLJBase
+using CSV
 using DataFrames
 
 x1 = ones(4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@
 # eg, `module TestDatasets` for code testing `datasets.jl`.
 
 using MLJ
+using MLJBase
+using CSV
 using Test
 
 @constant junk=KNNRegressor()

--- a/test/tuning.jl
+++ b/test/tuning.jl
@@ -4,7 +4,8 @@ module TestTuning
 using Test
 using MLJ
 # using UnicodePlots
-import MLJBase
+using MLJBase
+using CSV
 
 x1 = rand(100);
 x2 = rand(100);


### PR DESCRIPTION
This pull request makes the following changes:
1. Add CSV as a test-only dependency

This pull request is related to the changes in https://github.com/alan-turing-institute/MLJBase.jl/pull/24