### PR TITLE
Fix #192: Add verbosity option to @load macro

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -13,7 +13,7 @@ pkgs = keys(MLJ.metadata())
 
 @load DecisionTreeClassifier
 @test @isdefined DecisionTreeClassifier
-@load DecisionTreeRegressor pkg=DecisionTree
+@load DecisionTreeRegressor pkg=DecisionTree verbosity=1
 @test @isdefined DecisionTreeRegressor
 
 end # module


### PR DESCRIPTION
This PR adds an option `verbosity` to `@load` which defaults to 0. Printing can get quite annoying for heavy ML research.

Fixes #192