### PR TITLE
Fix link to ipynb tour

### DIFF
--- a/docs/src/tour.ipynb
+++ b/docs/src/tour.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The MLJ tour has moved to [here](https://github.com/alan-turing-institute/MLJ.jl/blob/master/examples/tour.ipynb)\n"
+    "The MLJ tour has moved to [here](https://github.com/alan-turing-institute/MLJ.jl/blob/master/examples/tour/tour.ipynb)\n"
    ]
   },
   {


### PR DESCRIPTION
The old link resulted in a 404 error.