### PR TITLE
Add parallelism tests for resampling

### DIFF
--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -462,7 +462,7 @@ end
 @static if VERSION >= v"1.3.0-DEV.573"
     function _evaluate!(func::Function, res::CPUThreads, nfolds, verbosity)
         task_vec = [Threads.@spawn func(k) for k in 1:nfolds]
-        return fetch.(task_vec)
+        return reduce(vcat, fetch.(task_vec))
     end
 end
 

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -44,7 +44,7 @@ function testset_accelerated(name::String, var, ex; exclude=[])
             end)
         end
     end
-    return final_ex
+    return esc(final_ex)
 end
 
 @test CV(nfolds=6) == CV(nfolds=6)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,10 +3,15 @@
 # this test code be wrapped in a module. Any new module name will do -
 # eg, `module TestDatasets` for code testing `datasets.jl`.
 
+using Distributed
+addprocs(2)
+
+@everywhere begin
 using MLJ
 using MLJBase
 using Test
 using Random
+end
 
 @constant junk=ConstantRegressor()
 


### PR DESCRIPTION
I set the number of workers to 2 since that's what the current code in `src/resampling.jl` tests to enable parallel execution.

Closes #207 