### PR TITLE
Simplifications to model search interface

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -45,4 +45,4 @@ deploydocs(
 #    modules = [MLJ]
 # Documenter can also automatically deploy documentation to gh-pages.
 # See "Hosting Documentation" and deploydocs() in the Documenter manual
-# for more information.
+# for more MLJBase.information.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -220,10 +220,12 @@ tree = DecisionTreeClassifier();
 scitype(tree)
 ```
 
-If, however, the relevant model code has not been loaded, one can nevertheless extract the scitypes from the model type's MLJ registry entry:
+If, however, the relevant model code has not been loaded, one can
+nevertheless extract the scitypes from the model type's MLJ registry
+entry:
 
 ```@repl doda
-info("DecisionTreeClassifier")
+traits("DecisionTreeClassifier")
 ```
 
 See also [Working with tasks](working_with_tasks.md) on searching for

--- a/docs/src/measures.md
+++ b/docs/src/measures.md
@@ -37,11 +37,11 @@ cross_entropy(ŷ, y)
 
 Notice that `l1` reports per-sample evaluations, while `rms`
 only reports an aggregated result. This and other behavior can be
-gleaned from measure *traits* which are summarized by the `info`
+gleaned from measure *traits* which are summarized by the `traits`
 method:
 
 ```@repl losses_and_scores
-info(l1)
+traits(l1)
 ```
 
 A user-defined measure in MLJ can be passed to the `evaluate!`

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -14,7 +14,7 @@ export @curve, @pcurve,                               # utilities.jl
         EnsembleModel,                                # ensembles.jl
         ConstantRegressor, ConstantClassifier,        # builtins/Constant.jl
         models, localmodels, @load, model,            # loading.jl
-        load_implementation,                          # loading.jl
+        load,                          # loading.jl
         KNNRegressor,                                 # builtins/KNN.jl
         @from_network, machines, sources, anonymize!, # composites.jl
         rebind!, fitresults                           # composites.jl

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -35,7 +35,7 @@ export FeatureSelector,
 export pdf, mode, median, mean, shuffle!, categorical, shuffle, levels, levels!
 
 # reexport from MLJBase and ScientificTypes:
-export nrows, nfeatures, info,
+export nrows, nfeatures, traits,
     selectrows, selectcols,
     SupervisedTask, UnsupervisedTask, MLJTask,
     Deterministic, Probabilistic, Unsupervised, Supervised,

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -13,18 +13,19 @@ Load the model implementation code for the model with specified `name` into the 
 See also [`@load`](@ref)
 
 """
-function load_implementation(handle::Handle; mod=Main, verbosity=1)
+function load_implementation(proxy::ModelProxy; mod=Main, verbosity=1)
     # get name, package and load path:
+    name = proxy.name
+    pkg = proxy.package_name
+    handle = (name=name, pkg=pkg)
     path = INFO_GIVEN_HANDLE[handle][:load_path]
     path_components = split(path, '.')
-    name = handle.name
-    pkg = handle.pkg
 
     # decide what to print
     toprint = verbosity > 0
 
     # return if model is already loaded
-    localnames = map(handle->handle.name, localmodels(mod=mod))
+    localnames = map(p->p.name, localmodels(mod=mod))
     if name ∈ localnames
         @info "A model named \"$name\" is already loaded. \n"*
         "Nothing new loaded. "

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -15,8 +15,7 @@ See also [`@load`](@ref)
 """
 function load_implementation(handle::Handle; mod=Main, verbosity=1)
     # get name, package and load path:
-    info = INFO_GIVEN_HANDLE[handle]
-    path = info[:load_path]
+    path = INFO_GIVEN_HANDLE[handle][:load_path]
     path_components = split(path, '.')
     name = handle.name
     pkg = handle.pkg
@@ -106,4 +105,3 @@ macro load(name_ex, kw_exs...)
 
     load_implementation(name, mod=__module__, pkg=pkg, verbosity=verbosity)
 end
-

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -6,14 +6,27 @@
 
 """
     
-    load_implementation(name::String; pkg=nothing, mod=Main, verbosity=1)
+    load(name::String; pkg=nothing, mod=Main, verbosity=1)
             
-Load the model implementation code for the model with specified `name` into the module `mod`, specifying `pkg` in the case of duplicate names. 
+Load the model implementation code for the model type with specified
+`name` into the module `mod`, specifying `pkg` if necesssary, to
+resolve duplicate names. 
+
+    load(proxy; pkg=nothing, mod=Main, verbosity=1)
+
+In the case that `proxy` is a return value of `model` (ie, has the
+form `(name = ..., package_name = ..., etc)`) this is equivalent to
+the previous call.  See the second example below.
+
+### Examples
+
+    load("ConstantClassifier")
+    load(localmodels()[1])     # same thing
 
 See also [`@load`](@ref)
 
 """
-function load_implementation(proxy::ModelProxy; mod=Main, verbosity=1)
+function load(proxy::ModelProxy; mod=Main, verbosity=0)
     # get name, package and load path:
     name = proxy.name
     pkg = proxy.package_name
@@ -58,8 +71,8 @@ function load_implementation(proxy::ModelProxy; mod=Main, verbosity=1)
     nothing
 end
 
-load_implementation(name::String; pkg=nothing, kwargs...) =
-    load_implementation(model(name, pkg=pkg); kwargs...)
+load(name::String; pkg=nothing, kwargs...) =
+    load(model(name, pkg=pkg); kwargs...)
 
 
 """
@@ -67,8 +80,8 @@ load_implementation(name::String; pkg=nothing, kwargs...) =
 
 
 Load the model implementation code for the model with specified `name`
-into the module `mod`, specifying `pkg` in the case of duplicate
-names. 
+into the calling module, provided `pkg` is specified in the case of
+duplicate names.
 
 ### Examples
 
@@ -76,7 +89,7 @@ names.
     @load PCA verbosity=1
     @load SVC pkg=LIBSVM 
 
-See also [`load_implementation`](@ref)
+See also [`load`](@ref)
 
 """
 macro load(name_ex, kw_exs...)
@@ -104,5 +117,5 @@ macro load(name_ex, kw_exs...)
     # "(MLJModels.Clustering).KMedoids":
     name = filter(name_) do c !(c in ['(',')']) end
 
-    load_implementation(name, mod=__module__, pkg=pkg, verbosity=verbosity)
+    load(name, mod=__module__, pkg=pkg, verbosity=verbosity)
 end

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -71,7 +71,7 @@ Base.show(stream::IO, ::MIME"text/plain", m::Measure) = print(stream, "$(measure
 Base.show(stream::IO, m::Measure) = print(stream, measurename(m))
 
 """
-    info(measure::Measure)
+    MLJBase.info(measure::Measure)
 
 Return a named tuple summarizing the traits defined for `measure`. 
 
@@ -95,7 +95,7 @@ Mean absolute error (also known as MAE).
 
 ``\\text{MAV} =  n^{-1}∑ᵢ|yᵢ-ŷᵢ|`` or ``\\text{MAV} =  ∑ᵢwᵢ|yᵢ-ŷᵢ|/∑ᵢwᵢ``
 
-For more information, run `info(mav)`.
+For more MLJBase.information, run `MLJBase.info(mav)`.
 
 """
 mav = MAV()
@@ -147,7 +147,7 @@ Root mean squared error:
 
 ``\\text{RMS} = \\sqrt{n^{-1}∑ᵢ|yᵢ-ŷᵢ|^2}`` or ``\\text{RMS} = \\sqrt{\\frac{∑ᵢwᵢ|yᵢ-ŷᵢ|^2}{∑ᵢwᵢ}}``
 
-For more information, run `info(rms)`.
+For more MLJBase.information, run `MLJBase.info(rms)`.
 
 """
 rms = RMS()
@@ -187,7 +187,7 @@ struct L2 <: Measure end
 
 L2 per-observation loss.
 
-For more information, run `info(l2)`.
+For more MLJBase.information, run `MLJBase.info(l2)`.
 
 """
 l2 = L2()
@@ -215,7 +215,7 @@ struct L1 <: Measure end
 
 L1 per-observation loss.
 
-For more information, run `info(l1)`.
+For more MLJBase.information, run `MLJBase.info(l1)`.
 
 """
 l1 = L1()
@@ -244,7 +244,7 @@ Root mean squared logarithmic error:
 
 ``\\text{RMSL} = n^{-1}∑ᵢ\\log\\left({yᵢ \\over ŷᵢ}\\right)``
 
-For more information, run `info(rmsl)`.
+For more MLJBase.information, run `MLJBase.info(rmsl)`.
 
 See also [`rmslp1`](@ref).
 
@@ -278,7 +278,7 @@ Root mean squared logarithmic error with an offset of 1:
 
 ``\\text{RMSLP1} = n^{-1}∑ᵢ\\log\\left({yᵢ + 1 \\over ŷᵢ + 1}\\right)``
 
-For more information, run `info(rmslp1)`.
+For more MLJBase.information, run `MLJBase.info(rmslp1)`.
 
 See also [`rmsl`](@ref).
 """
@@ -313,7 +313,7 @@ Root mean squared percentage loss:
 where the sum is over indices such that `yᵢ≂̸0` and `m` is the number
 of such indices.
 
-For more information, run `info(rmsp)`.
+For more MLJBase.information, run `MLJBase.info(rmsp)`.
 
 """
 rmsp = RMSP()
@@ -353,7 +353,7 @@ Returns the rate of misclassification of the (point) predictions `ŷ`,
 given true observations `y`, optionally weighted by the weights
 `w`. All three arguments must be abstract vectors of the same length.
 
-For more information, run `info(misclassification_rate)`.
+For more MLJBase.information, run `MLJBase.info(misclassification_rate)`.
 
 """
 misclassification_rate = MisclassificationRate()
@@ -382,7 +382,7 @@ probabilistic predictions) and an abstract vector of true observations
 `y`, return the negative log-probability that each observation would
 occur, according to the corresponding probabilistic prediction.
 
-For more information, run `info(cross_entropy)`.
+For more MLJBase.information, run `MLJBase.info(cross_entropy)`.
 
 """
 cross_entropy = CrossEntropy()

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -71,12 +71,12 @@ Base.show(stream::IO, ::MIME"text/plain", m::Measure) = print(stream, "$(measure
 Base.show(stream::IO, m::Measure) = print(stream, measurename(m))
 
 """
-    MLJBase.info(measure::Measure)
+    traits(measure::Measure)
 
 Return a named tuple summarizing the traits defined for `measure`. 
 
 """
-MLJBase.info(measure::Measure) = (target_scitype=target_scitype(measure),
+traits(measure::Measure) = (target_scitype=target_scitype(measure),
                             prediction_type=prediction_type(measure),
                             orientation=orientation(measure),
                             reports_each_observation=reports_each_observation(measure),

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -29,6 +29,7 @@ function localmodeltypes(mod)
         i = MLJBase.info(M)
         name = i[:name]
         isdefined(mod, Symbol(name)) &&
+            !i[:is_wrapper] && 
             !(M in [Supervised, Unsupervised, Deterministic,
                     Probabilistic, DeterministicNetwork,
                     ProbabilisticNetwork, UnsupervisedNetwork])

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -23,25 +23,33 @@ end
 
 ## FUNCTIONS TO BUILD GLOBAL METADATA CONSTANTS IN MLJ INITIALIZATION
 
+# get the model types in top-level of given module's namespace:
+function localmodeltypes(mod)
+    return filter(MLJBase.finaltypes(Model)) do M
+        i = MLJBase.info(M)
+        name = i[:name]
+        isdefined(mod, Symbol(name)) &&
+            !(M in [Supervised, Unsupervised, Deterministic,
+                    Probabilistic, DeterministicNetwork,
+                    ProbabilisticNetwork, UnsupervisedNetwork])
+    end
+end
+
 # for use in __init__ to define INFO_GIVEN_HANDLE
 function info_given_handle(metadata_file)
 
-    # get the metadata for MLJ models:
-    metadata = LittleDict(TOML.parsefile(metadata_file))
-    localmodels = MLJBase.finaltypes(Model)
-    info_given_model = Dict()
-    for M in localmodels
-        _info = MLJBase.info(M)
-        if !(_info[:is_wrapper]) &&
-            !(M in [DeterministicNetwork, ProbabilisticNetwork])
-            modelname = _info[:name]
-            info_given_model[modelname] = _info
-        end
+    # build the metadata for built-in models:
+    modeltypes = localmodeltypes(MLJ)
+    info_given_name = Dict()
+    for M in modeltypes
+        i = MLJBase.info(M)
+        info_given_name[i[:name]] = i
     end
         
     # merge with the decoded external metadata:
+    metadata = LittleDict(TOML.parsefile(metadata_file))
     metadata_given_pkg = decode_dic(metadata)
-    metadata_given_pkg["MLJ"] = info_given_model
+    metadata_given_pkg["MLJ"] = info_given_name
 
     # build info_given_handle dictionary:
     ret = Dict{Handle}{Any}()

--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -142,7 +142,6 @@ function models(task::SupervisedTask)
     function condition(handle)
         t = traits(handle)
         return t.is_supervised &&
-            t.is_wrapper == false &&
             task.target_scitype <: t.target_scitype &&
             task.input_scitype <: t.input_scitype &&
             task.is_probabilistic == t.is_probabilistic
@@ -154,8 +153,7 @@ function models(task::UnsupervisedTask)
     ret = Dict{String, Any}()
     function condition(handle)
         t = traits(handle)
-        return t.is_wrapper == false &&
-            task.input_scitype <: t.input_scitype
+        return task.input_scitype <: t.input_scitype
     end
     return models(condition)
 end

--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -108,10 +108,10 @@ that may not be loaded).
 
 List all models matching the specified `task`. 
 
-    models(condition)
+    models(conditions...)
 
-List all models matching a given condition. A *condition* is any
-`Bool`-valued function on models.
+List all models satisifying the specified `conditions`. A *condition*
+is any `Bool`-valued function on models.
 
 Excluded in the listings are the built-in model-wraps `EnsembleModel`,
 `TunedModel`, and `IteratedModel`.
@@ -128,8 +128,12 @@ predictions.
 See also: [`localmodels`](@ref).
 
 """
-models(condition) =
-    sort!(filter(condition, model.(keys(INFO_GIVEN_HANDLE))))
+function models(conditions...)
+    unsorted = filter(model.(keys(INFO_GIVEN_HANDLE))) do model
+        all(c(model) for c in conditions)
+    end
+    return sort!(unsorted)
+end
 
 models() = models(x->true)
 
@@ -159,12 +163,13 @@ end
 """
     localmodels(; mod=Main)
     localmodels(task::MLJTask; mod=Main)
-    localmodels(condition; mod=Main)
+    localmodels(conditions...; mod=Main)
  
 
 List all models whose names are in the namespace of the specified
 module `mod`, additionally solving the `task`, or meeting the
-`condition`, if specified.
+`conditions`, if specified. A *condition* is a `Bool`-valued function
+on models.
 
 See also [models](@ref)
 

--- a/src/registry/src/Registry.jl
+++ b/src/registry/src/Registry.jl
@@ -83,11 +83,11 @@ function _update(mod, test_env_only)
             meta_given_package[pkg] = Dict()
         end
         for M in modeltypes
-            _info = MLJBase.info(M)
-            pkg = _info[:package_name]
+            _MLJBase.info = MLJBase.info(M)
+            pkg = _MLJBase.info[:package_name]
             if !(pkg in ["unknown", "MLJ"]) 
-                modelname = _info[:name]
-                meta_given_package[pkg][modelname] = _info
+                modelname = _MLJBase.info[:name]
+                meta_given_package[pkg][modelname] = _MLJBase.info
             end
         end
         open(joinpath(MLJ.Registry.srcdir, "../Metadata.toml"), "w") do file

--- a/test/Constant.jl
+++ b/test/Constant.jl
@@ -3,6 +3,7 @@ module TestConstant
 # using Revise
 using Test
 using MLJ
+import MLJBase
 using CategoricalArrays
 import Distributions
 
@@ -21,8 +22,8 @@ d=Distributions.Normal(1.5, 0.5)
 @test predict(model, fitresult, X) == fill(d, 10)
 @test predict_mean(model, fitresult, X) == fill(1.5, 10)
 
-info(model)
-info(MLJ.DeterministicConstantRegressor)
+MLJBase.info(model)
+MLJBase.info(MLJ.DeterministicConstantRegressor)
 
 
 ## CLASSIFIER
@@ -43,8 +44,8 @@ yhat = predict_mode(model, fitresult, X)
 yhat = predict(model, fitresult, X)
 @test yhat == fill(d, 10)
 
-info(model)
-info(MLJ.DeterministicConstantClassifier)
+MLJBase.info(model)
+MLJBase.info(MLJ.DeterministicConstantClassifier)
 
 end # module
 true

--- a/test/KNN.jl
+++ b/test/KNN.jl
@@ -3,6 +3,7 @@ module TestKNN
 # using Revise
 using Test
 using MLJ
+import MLJBase
 
 Xtr = [4 2 5 3;
        2 1 6 0.0];
@@ -26,7 +27,7 @@ knn.K = 2
 fitresult, cache, report = MLJ.update(knn, 0, fitresult, cache, X, y); 
 @test predict(knn, fitresult, Xtest)[1] !=  ypred
 
-info(knn)
+MLJBase.info(knn)
 
 N =100
 X = (x1=rand(N), x2=rand(N), x3=rand(N))

--- a/test/Transformers.jl
+++ b/test/Transformers.jl
@@ -18,7 +18,7 @@ X = (Zn=rand(N),
 
 namesX = schema(X).names |> collect
 selector = FeatureSelector()
-info(selector)
+MLJBase.info(selector)
 fitresult, cache, report = MLJBase.fit(selector, 1, X)
 @test fitresult == namesX
 transform(selector, fitresult, selectrows(X, 1:2))
@@ -29,7 +29,7 @@ fitresult, cache, report = MLJBase.fit(selector, 1, X)
 
 # `UnivariateStandardizer`:
 stand = UnivariateStandardizer()
-info(stand)
+MLJBase.info(stand)
 #fit!(stand, 1:3)
 fitresult, cache, report = MLJBase.fit(stand, 1, [0, 2, 4])
 @test round.(Int, transform(stand, fitresult, [0,4,8])) == [-1.0,1.0,3.0]
@@ -52,7 +52,7 @@ x4 = [round(Int, x) for x in X.x1stFlrSF]
 X = (x1=x1, x2=X[2], x3=X[3], x4=x4, x5=X[5])
 
 stand = Standardizer()
-info(stand)
+MLJBase.info(stand)
 fitresult, cache, report = MLJBase.fit(stand, 1, X)
 Xnew = transform(stand, fitresult, X)
 @test Xnew[1] == X[1]
@@ -82,7 +82,7 @@ v = v .- minimum(v)
 MLJ.Transformers.normality(v)
 
 t = UnivariateBoxCoxTransformer(shift=true)
-info(t)
+MLJBase.info(t)
 fitresult, cache, report = MLJBase.fit(t, 2, v)
 @test sum(abs.(v - MLJBase.inverse_transform(t, fitresult, MLJBase.transform(t, fitresult, v)))) <= 5000*eps()
 
@@ -95,7 +95,7 @@ X = (name=categorical(["Ben", "John", "Mary", "John"], ordered=true),
      age=[23, 23, 14, 23])
 
 t = OneHotEncoder()
-info(t)
+MLJBase.info(t)
 fitresult, cache, _ =
     @test_logs((:info, r"Spawning 3"),
                (:info, r"Spawning 3"),

--- a/test/ensembles.jl
+++ b/test/ensembles.jl
@@ -61,7 +61,7 @@ d = predict(wens, weights, X)[1]
 
 
 ## ENSEMBLE MODEL
-;;;;
+
 # target is :deterministic :multiclass false:
 atom=MLJ.DeterministicConstantClassifier()
 X = MLJ.table(ones(5,3))
@@ -76,7 +76,7 @@ weights = weights/sum(weights)
 ensemble_model.weights = weights
 fitresult, cache, report = MLJ.fit(ensemble_model, 1, X, y)
 predict(ensemble_model, fitresult, MLJ.selectrows(X, test))
-info(ensemble_model)
+MLJBase.info(ensemble_model)
 @test MLJBase.target_scitype(ensemble_model) == MLJBase.target_scitype(atom)
 
 # target is :deterministic :continuous false:
@@ -97,7 +97,7 @@ weights = rand(10)
 weights = weights/sum(weights)
 ensemble_model.weights = weights
 predict(ensemble_model, fitresult, MLJ.selectrows(X, test))
-info(ensemble_model)
+MLJBase.info(ensemble_model)
 
 # target is :deterministic :continuous false:
 atom = MLJ.DeterministicConstantRegressor()
@@ -139,7 +139,7 @@ weights = rand(10)
 weights = weights/sum(weights)
 ensemble_model.weights = weights
 predict(ensemble_model, fitresult, MLJ.selectrows(X, test))
-info(ensemble_model)
+MLJBase.info(ensemble_model)
 # @test MLJBase.output_is(ensemble_model) == MLJBase.output_is(atom)
 
 # target is :probabilistic :continuous false:
@@ -167,7 +167,7 @@ weights = rand(10)
 weights = weights/sum(weights)
 ensemble_model.weights = weights
 predict(ensemble_model, fitresult, MLJ.selectrows(X, test))
-info(ensemble_model)
+MLJBase.info(ensemble_model)
 # @test MLJBase.output_is(ensemble_model) == MLJBase.output_is(atom)
 
 # test generic constructor:

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -9,6 +9,7 @@ using MLJ
     @test (@isdefined DecisionTreeClassifier)
     @test_logs((:info, r"^A model named"),
                load_implementation("DecisionTreeClassifier", mod=TestLoading))
+    @test model("DecisionTreeClassifier") in localmodels(mod=TestLoading)
 end
 
 end # module

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -8,7 +8,7 @@ using MLJ
     @load DecisionTreeClassifier pkg=DecisionTree verbosity=1
     @test (@isdefined DecisionTreeClassifier)
     @test_logs((:info, r"^A model named"),
-               load_implementation("DecisionTreeClassifier", mod=TestLoading))
+               load("DecisionTreeClassifier", mod=TestLoading))
     @test model("DecisionTreeClassifier") in localmodels(mod=TestLoading)
 end
 

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -13,18 +13,11 @@ i = MLJ.info_given_handle(metadata_file)[cnst]
 
 @testset "building INFO_GIVEN_HANDLE" begin
     @test isempty(MLJ.localmodeltypes(MLJBase))
-    @test issubset(Set([MLJ.SimpleDeterministicCompositeModel,
-                        FooBarRegressor,
-                        KNNRegressor,                                
+    @test issubset(Set([KNNRegressor,                                
                         MLJ.Constant.DeterministicConstantClassifier,
                         MLJ.Constant.DeterministicConstantRegressor, 
-                        MLJ.DeterministicEnsembleModel,              
-                        MLJ.DeterministicTunedModel,                 
                         ConstantClassifier,                          
                         ConstantRegressor,                           
-                        MLJ.ProbabilisticEnsembleModel,              
-                        MLJ.ProbabilisticTunedModel,                 
-                        Resampler,                                   
                         FeatureSelector,                             
                         OneHotEncoder,                               
                         Standardizer,                                

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -3,15 +3,35 @@ module TestMetadata
 # using Revise
 using Test
 using MLJ
+import MLJBase
 
 metadata_file = joinpath(@__DIR__, "..", "src", "registry", "Metadata.toml")
 pca = MLJ.Handle("PCA", "MultivariateStats")
 cnst = MLJ.Handle("ConstantRegressor", "MLJ")
 i = MLJ.info_given_handle(metadata_file)[cnst]
 
+
 @testset "building INFO_GIVEN_HANDLE" begin
+    @test isempty(MLJ.localmodeltypes(MLJBase))
+    @test issubset(Set([MLJ.SimpleDeterministicCompositeModel,
+                        FooBarRegressor,
+                        KNNRegressor,                                
+                        MLJ.Constant.DeterministicConstantClassifier,
+                        MLJ.Constant.DeterministicConstantRegressor, 
+                        MLJ.DeterministicEnsembleModel,              
+                        MLJ.DeterministicTunedModel,                 
+                        ConstantClassifier,                          
+                        ConstantRegressor,                           
+                        MLJ.ProbabilisticEnsembleModel,              
+                        MLJ.ProbabilisticTunedModel,                 
+                        Resampler,                                   
+                        FeatureSelector,                             
+                        OneHotEncoder,                               
+                        Standardizer,                                
+                        UnivariateBoxCoxTransformer,
+                        UnivariateStandardizer]), MLJ.localmodeltypes(MLJ))
     @test MLJ.info_given_handle(metadata_file)[pca][:name] == "PCA"
-    @test MLJ.info_given_handle(metadata_file)[cnst] == info(ConstantRegressor)
+    @test MLJ.info_given_handle(metadata_file)[cnst] == MLJBase.info(ConstantRegressor)
 end
 
 h = Vector{Any}(undef, 7)

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -64,8 +64,6 @@ end
 
 @testset "Handle constructors" begin
     @test MLJ.Handle("PCA") == MLJ.Handle("PCA", "MultivariateStats")
-    @test MLJ.model("PCA") == MLJ.Handle("PCA", "MultivariateStats")
-    @test_throws ArgumentError MLJ.model("Julia")
     # TODO: add tests here when duplicate model names enter registry
 end
 

--- a/test/model_search.jl
+++ b/test/model_search.jl
@@ -4,14 +4,13 @@ module TestModelSearch
 using Test
 using MLJ
 
-pca = MLJ.Handle("PCA", "MultivariateStats")
-cnst = MLJ.Handle("ConstantRegressor", "MLJ")
+pca = model("PCA", pkg="MultivariateStats")
+cnst = model("ConstantRegressor", pkg="MLJ")
 
-@test traits(model("ConstantRegressor")) == traits(cnst)
-@test traits(ConstantRegressor) == traits(cnst)
-traits(ConstantRegressor()) == traits(cnst)
-@test traits(model("PCA")) == traits(pca)
+@test_throws ArgumentError MLJ.model("Julia")
 
+@test traits(ConstantRegressor) == cnst
+@test traits(Standardizer()) == model("Standardizer", pkg="MLJ")
 
 @testset "localmodels" begin
     tree = model("DecisionTreeRegressor")
@@ -24,7 +23,7 @@ traits(ConstantRegressor()) == traits(cnst)
 end
 
 @testset "models() and localmodels" begin
-    t(handle) = traits(handle).is_pure_julia
+    t(model) = model.is_pure_julia
     mods = models(t)
     @test pca in mods
     @test cnst in mods

--- a/test/model_search.jl
+++ b/test/model_search.jl
@@ -31,6 +31,9 @@ end
     mods = localmodels(t, mod=TestModelSearch)
     @test cnst in mods
     @test !(pca in mods)
+    u(model) = !(model.is_supervised)
+    @test pca in models(u, t)
+    @test !(cnst in models(u, t))
 end
 
 end

--- a/test/model_search.jl
+++ b/test/model_search.jl
@@ -4,10 +4,14 @@ module TestModelSearch
 using Test
 using MLJ
 
-metadata_file = joinpath(@__DIR__, "..", "src", "registry", "Metadata.toml")
 pca = MLJ.Handle("PCA", "MultivariateStats")
 cnst = MLJ.Handle("ConstantRegressor", "MLJ")
-i = MLJ.info_given_handle(metadata_file)[cnst]
+
+@test traits(model("ConstantRegressor")) == traits(cnst)
+@test traits(ConstantRegressor) == traits(cnst)
+traits(ConstantRegressor()) == traits(cnst)
+@test traits(model("PCA")) == traits(pca)
+
 
 @testset "localmodels" begin
     tree = model("DecisionTreeRegressor")
@@ -20,7 +24,7 @@ i = MLJ.info_given_handle(metadata_file)[cnst]
 end
 
 @testset "models() and localmodels" begin
-    t(handle) = info(handle)[:is_pure_julia]
+    t(handle) = traits(handle).is_pure_julia
     mods = models(t)
     @test pca in mods
     @test cnst in mods

--- a/test/tuning.jl
+++ b/test/tuning.jl
@@ -30,7 +30,7 @@ tuned_model = TunedModel(model=composite, tuning=grid,
                          resampling=holdout, measure=rms,
                          ranges=ranges, full_report=false)
 
-info(tuned_model)
+MLJBase.info(tuned_model)
 
 tuned = machine(tuned_model, X, y)
 


### PR DESCRIPTION
- instead of model("PCA") just returning the handle of "PCA" (ie, (name="PCA", pkg="MultivariateStats")), it returns the whole metadata entry, eliminating need for separate "traits" method. 

- instead of only returning handles, `models()` now returns list of full metadata entries, but with pretty printing to hide details

- a query like `models() do model traits(model).is_pure_julia end` now simplifies to `models() do model.is_pure_julia end`