### PR TITLE
Have @load return an instance; update manual accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Pkg.add("MLJ")
 Pkg.add("MLJModels")
 ```
 
-To obtain a dictionary of all registered models, keyed on package name:
+To obtain a list of all registered models, keyed on package name:
 
 ```julia
 using MLJ
@@ -63,23 +63,19 @@ models()
 To add a package - for example,  DecisionTree - to your load path:
 
 ```julia
-julia> models()["DecisionTree"]
-2-element Array{Any,1}:
- "DecisionTreeRegressor" 
- "DecisionTreeClassifier"
 using Pkg
 Pkg.add("DecisionTree")
 ```
 
-To load all code needed to use a model - for example, DecisionTreeClassifier:
+To load all code needed to use a model - for example, DecisionTreeClassifier,
 
 ```julia
 @load DecisionTreeClassifier
 ```
 
-Refer to the
+which also returns a default instance. Refer to the
 [documentation](https://alan-turing-institute.github.io/MLJ.jl/stable/)
-for for instantiating and running loaded models.
+for more on instantiating and running loaded models.
 
 
 **Package conflicts.** If you encounter package conflicts during

--- a/docs/src/evaluating_model_performance.md
+++ b/docs/src/evaluating_model_performance.md
@@ -19,8 +19,7 @@ using MLJ
 MLJ.color_off() # hide
 X = (a=rand(12), b=rand(12), c=rand(12));
 y = X.a + 2X.b + 0.05*rand(12);
-@load RidgeRegressor
-model = RidgeRegressor()
+model = @load RidgeRegressor
 cv=CV(nfolds=3)
 evaluate(model, X, y, resampling=cv, measure=l2)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,15 +26,21 @@ X = iris[:, 1:4];
 y = iris[:, 5];
 ```
 
-In MLJ a *model* is a struct storing the hyperparameters of the learning
-algorithm indicated by the struct name.  Assuming the DecisionTree
-package is in your load path, we can instantiate a
-DecisionTreeClassifier model like this:
+In MLJ a *model* is a struct storing the hyperparameters of the
+learning algorithm indicated by the struct name.  Assuming the
+DecisionTree package is in your load path, we can use `@load` to load
+the code defining the `DecisionTreeClassifier` model type. This macro
+also returns an instance, with default hyperparameters:
 
 ```@repl doda
 using MLJ
-@load DecisionTreeClassifier verbosity=1
-tree_model = DecisionTreeClassifier(max_depth=2)
+tree_model = @load DecisionTreeClassifier verbosity=1
+```
+
+```julia 
+julia> tree_model.max_depth = 2
+julia> tree_model == DecisionTreeClassfier(max_depth=2)
+true
 ```
 
 *Important:* DecisionTree and most other packages implementing machine
@@ -160,6 +166,7 @@ type.
 
 
 ![](scitypes.png)
+*Figure 1. Part of the scientific type heirarchy in* ScientificTypes.jl.
 
 ```@repl doda
 scitype(4.6)
@@ -182,8 +189,6 @@ of the columns, which can be individually inspected using `schema`:
 ```@repl doda
 schema(X)
 ```
-
-*Figure 1. Part of the scientific type heirarchy in* ScientificTypes.jl.
 
 
 #### Inputs

--- a/docs/src/tuning_models.md
+++ b/docs/src/tuning_models.md
@@ -17,8 +17,7 @@ way the wrapped model may be viewed as a "self-tuning" version of the
 using MLJ
 X = (x1=rand(100), x2=rand(100), x3=rand(100))
 y = 2X.x1 - X.x2 + 0.05*rand(100)
-@load DecisionTreeRegressor
-tree_model = DecisionTreeRegressor()
+tree_model = @load DecisionTreeRegressor
 ```
     
 Let's tune `min_purity_increase` in the model

--- a/docs/src/working_with_tasks.md
+++ b/docs/src/working_with_tasks.md
@@ -105,7 +105,7 @@ models(task)
 Binding a model to a task and evaluating performance:
 
 ```@example 1
-@load DecisionTreeClassifier
+@load DecisionTreeClassifier;
 mach = machine(DecisionTreeClassifier(), task)
 evaluate!(mach, operation=predict_mode, resampling=Holdout(), measure=misclassification_rate, verbosity=0)
 ```

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -40,8 +40,8 @@ function load(proxy::ModelProxy; mod=Main, verbosity=0)
     # return if model is already loaded
     localnames = map(p->p.name, localmodels(mod=mod))
     if name ∈ localnames
-        @info "A model named \"$name\" is already loaded. \n"*
-        "Nothing new loaded. "
+        @info "A model type \"$name\" is already loaded. \n"*
+        "No new code loaded. "
         return
     end
 
@@ -118,4 +118,14 @@ macro load(name_ex, kw_exs...)
     name = filter(name_) do c !(c in ['(',')']) end
 
     load(name, mod=__module__, pkg=pkg, verbosity=verbosity)
+
+    esc(quote
+        try
+            $name_ex()
+        catch
+            @warn "Code is loaded but no instance returned. "
+            nothing
+        end
+    end)
+    
 end

--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -139,8 +139,7 @@ models() = models(x->true)
 
 function models(task::SupervisedTask)
     ret = Dict{String, Any}()
-    function condition(handle)
-        t = traits(handle)
+    function condition(t)
         return t.is_supervised &&
             task.target_scitype <: t.target_scitype &&
             task.input_scitype <: t.input_scitype &&

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -5,9 +5,10 @@ using Test
 using MLJ
 
 @testset "loading of model implementations" begin
-    @load DecisionTreeClassifier pkg=DecisionTree verbosity=1
+    tree = @load DecisionTreeClassifier pkg=DecisionTree verbosity=1
     @test (@isdefined DecisionTreeClassifier)
-    @test_logs((:info, r"^A model named"),
+    @test tree == DecisionTreeClassifier()
+    @test_logs((:info, r"^A model"),
                load("DecisionTreeClassifier", mod=TestLoading))
     @test model("DecisionTreeClassifier") in localmodels(mod=TestLoading)
 end


### PR DESCRIPTION
`@load` now returns a mode instance with default hyperparameters, as in `tree_model = @load DecisionTreeRegressor`