### PR TITLE
report() and fitted_params() for exported learning networks

### DIFF
--- a/src/networks.jl
+++ b/src/networks.jl
@@ -424,6 +424,9 @@ machine(model::Model, X, y::AbstractNode) = NodalMachine(model, source(X), y)
 machine(model::Model, X::AbstractNode, y) = NodalMachine(model, X, source(y))
 
 MLJBase.matrix(X::AbstractNode) = node(MLJBase.matrix, X)
+MLJBase.table(X::AbstractNode) = node(MLJBase.table, X)
+Base.vcat(args::AbstractNode...) = node(vcat, args...)
+Base.hcat(args::AbstractNode...) = node(hcat, args...)
 
 Base.log(X::AbstractNode) = node(v->log.(v), X)
 Base.exp(X::AbstractNode) = node(v->exp.(v), X)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -233,12 +233,15 @@ function pretty_table(X; showtypes=true, alignment=:l, kwargs...)
     else
         header  = names
     end
+    show_color = MLJBase.SHOW_COLOR
+    color_off()
     try
         PrettyTables.pretty_table(MLJBase.matrix(X),
                                   header; alignment=alignment, kwargs...)
     catch
         println("Trouble displaying evaluation results.")
     end
+    ifelse(show_color, color_on(), color_off())
 end
 
 

--- a/test/networks.jl
+++ b/test/networks.jl
@@ -155,6 +155,15 @@ knn_.K =67
            (:info, r"Updating"),
            fit!(yhat, verbosity=1))
 
+A  = rand(2,3)
+As = source(A)
+@test MLJ.matrix(MLJ.table(As))() == A
+
+y = rand(4)
+ys = source(y)
+@test vcat(ys, ys)() == vcat(y, y)
+@test hcat(ys, ys)() == hcat(y, y)
+
 end
 
 true


### PR DESCRIPTION
- If `composite` is a a learning network exported as a model, and `m = machine(composite, args...)` then `report(m)` returns the reports for each machine in the learning network, and similarly for `fitted_params(m)`. 

- `MLJ.table`, `vcat` and `hcat` now overloaded for `AbstractNode`, so that they can immediately be used in defining learning networks. For example, if `X = source(rand(20,3))` and `y=source(rand(20))` then `MLJ.table(X)` and `vcat(y, y)` both make sense and define new nodes.