### PR TITLE
Broaden MLJ's parallel horizons in resampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.5.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+ComputationalResources = "ed09eef8-17a6-5b46-8889-db040fac31e3"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -34,7 +34,8 @@ pages = Any["Getting Started"=>"index.md",
             "MLJ Cheatsheet" => "mlj_cheatsheet.md",
             "MLJ News"=>"NEWS.md",
             "FAQ" => "frequently_asked_questions.md",
-            "Julia BlogPost"=>"julia_blogpost.md"]
+            "Julia BlogPost"=>"julia_blogpost.md",
+            "Acceleration and Parallelism"=>"acceleration_and_parallelism.md"]
 
 for p in pages
     println(first(p))

--- a/docs/src/acceleration_and_parallelism.md
+++ b/docs/src/acceleration_and_parallelism.md
@@ -1,0 +1,35 @@
+# Acceleration and Parallelism
+
+!!! warning "Experimental API"
+
+    The acceleration API is experimental and may not work correctly in all
+    cases, especially if trying to use an acceleration method that your
+    version of Julia or installed packages cannot support. The API is also
+    subject to breaking changes during minor or major releases without
+    warning.
+
+### User-facing interface
+
+To enable composable, extensible acceleration of core MLJ methods,
+[ComputationalResources.jl](https://github.com/timholy/ComputationalResources.jl)
+is utilized to provide some basic types and functions to make implementing
+acceleration easy. However, ambitious users or package authors have the option
+to define their own types to be passed as resources to `acceleration`, which
+must be `<:ComputationalResources.AbstractResource`.
+
+Methods which support some form of acceleration support the `acceleration`
+keyword argument, which can be passed a "resource" from
+`ComputationalResources`. For example, passing `acceleration=CPUProcesses()`
+will utilize `Distributed`'s multiprocessing functionality to accelerate the
+computation, while `acceleration=CPUThreads()` will use Julia's PARTR
+threading model to perform acceleration.
+
+The default computational resource is `CPU1()`, which is simply serial
+processing via CPU. The default resource can be changed by setting
+`MLJ.DEFAULT_RESOURCE[]` to an instance of
+`ComputationalResources.AbstractResource`.
+
+!!! note
+
+    The `CPUThreads()` dispatch is only available when running a version of
+    Julia with `Threads.@spawn` available.

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -86,6 +86,9 @@ import PrettyTables
 import Random
 using ScientificTypes
 import ScientificTypes
+using ComputationalResources
+import ComputationalResources: CPUProcesses
+const DEFAULT_RESOURCE = Ref{AbstractResource}(CPU1())
 
 # convenience packages
 using DocStringExtensions: SIGNATURES, TYPEDEF

--- a/src/tuning.jl
+++ b/src/tuning.jl
@@ -19,11 +19,12 @@ See also [TunedModel](@ref), [range](@ref).
 """
 mutable struct Grid <: TuningStrategy
     resolution::Union{Int,Vector{<:Pair{<:ParameterName,Int}}}
-    parallel::Bool
+    acceleration::AbstractResource
 end
 
 # Constructor with keywords
-Grid(; resolution=10, parallel::Bool=true) = Grid(resolution, parallel)
+Grid(; resolution=10, acceleration::AbstractResource=DEFAULT_RESOURCE[]) =
+    Grid(resolution, acceleration)
 
 MLJBase.show_as_constructed(::Type{<:Grid}) = true
 


### PR DESCRIPTION
This PR refactors the existing distributed functionality to use dispatch so that more parallelism/acceleration methods can be easily added over time. The ideal is to expose this mechanism to the user/package author so that their very fancy parallel execution model will work just as well, without further changes to MLJ (they only need to override the appropriate methods).

This is WIP; I still need to rebase on #217 for tests (and add tests for multithreading), as well as adapt ensembles to use the same mechanism. Also, I want to find a nicer mechanism than the `parallel` keyword to trigger parallel execution.

TODO:
- [x] Modify ensembles to support new acceleration logic
- [x] Add documentation for `acceleration` kwarg
- [x] Add parallel/acceleration fields to `Resample` struct, with the values passed as keyword arguments to the call to `evaluate!` in fit(::Resample, ...). Nevermind the `update` method for `Holdout` - this is not parallizable.
