### PR TITLE
Cheatsheet Terminology Clarification

### DIFF
--- a/docs/src/mlj_cheatsheet.md
+++ b/docs/src/mlj_cheatsheet.md
@@ -60,9 +60,9 @@ y, X =  unpack(channing,
                :Cens=>Multiclass)
 ```
 
-Splitting row indices into train/evaluate/test:
+Splitting row indices into train/validate/test:
 
-`train, evaluate, test = partition(eachindex(y), 0.7, 0.2, shuffle=true, rng=1234)` for 70:20:10 ratio
+`train, validate, test = partition(eachindex(y), 0.7, 0.2, shuffle=true, rng=1234)` for 70:20:10 ratio
 
 
 #### Machine construction


### PR DESCRIPTION
Minor documentation clarification, changing `train/evaluate/test` in the context of splitting row indices to `train/validate/test`, which is more in line with expected lingo, and does't conflict with the actual `evaluate` function in MLJ. From this Slack channel discussion I raised: https://julialang.slack.com/archives/CC57ZE7EY/p1568917611002300
