### PR TITLE
Direct access to hyperparameters for a node

### DIFF
--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -91,7 +91,7 @@ import ScientificTypes
 using DocStringExtensions: SIGNATURES, TYPEDEF
 
 # to be extended:
-import Base.==
+import Base: ==, getindex, setindex!
 import StatsBase.fit!
 
 # from Standard Library:

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -103,3 +103,7 @@ if VERSION ≥ v"1.3.0-"
     inverse_transform(node::Node{<:NodalMachine{<:Unsupervised}}) =
         data->inverse_transform(node.machine, data)
 end # version ≥ 1.3
+
+# Syntactic sugar to directly access hyperparameters
+getindex(n::Node{<:NodalMachine{<:Model}}, s::Symbol) = getproperty(n.machine.model, s)
+setindex!(n::Node{<:NodalMachine{<:Model}}, v, s::Symbol) = setproperty!(n.machine.model, s, v)

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -33,6 +33,11 @@ if VERSION ≥ v"1.3.0-"
         fit!(ŷ, rows=train)
 
         @test isapprox(rms(ŷ(rows=test), ys(rows=test)), 0.627123, rtol=1e-4)
+
+        # shortcut to get and set hyperparameters of a node
+        ẑ[:lambda] = 5.0
+        fit!(ŷ, rows=train)
+        @test isapprox(rms(ŷ(rows=test), ys(rows=test)), 0.62699, rtol=1e-4)
     end
 end # version
 


### PR DESCRIPTION
This allows the following:

```julia
ẑ = (W, z) |> RidgeRegressor(lambda=0.1)
ŷ = ẑ |> inverse_transform(z)
fit!(ŷ, rows=train)

# direct access to lambda parameter:
ẑ[:lambda] = 5.0
fit!(ŷ, rows=train)
```

This is particularly  convenient when using this "pipeline" syntax where you may not want to write somewhere explicitly  `ridge = RidgeRegressor(lambda=0.1)` and then update `ridge.lambda`.