### PR TITLE
Add `mean`, `median`, and `mode` for `Nodes`

### DIFF
--- a/docs/src/NEWS.md
+++ b/docs/src/NEWS.md
@@ -16,9 +16,15 @@ News for MLJ and its satellite packages: [MLJBase](https://github.com/alan-turin
 
 ## News
 
+### 22 Oct 2019
+
+MLJ 0.5.1 released.
+
 ### 21 Oct 2019
 
-ScientificTypes 0.2.2 released.
+- ScientificTypes 0.2.2 released.
+
+- MLJModels  0.5.2 released
 
 ### 17 Oct 2019
 
@@ -26,7 +32,7 @@ MLJBase 0.7 released.
 
 ### 11 Oct 2019
 
-MLJ 0.5.1 released.
+MLJModels 0.5.1 released.
 
 ### 30 Sep 2019
 

--- a/src/networks.jl
+++ b/src/networks.jl
@@ -440,6 +440,7 @@ Base.hcat(args::AbstractNode...) = node(hcat, args...)
 
 Statistics.mean(X::AbstractNode) = node(v->mean.(v), X)
 Statistics.median(X::AbstractNode) = node(v->median.(v), X)
+import StatsBase.mode
 StatsBase.mode(X::AbstractNode) = node(v->mode.(v), X)
 
 Base.log(X::AbstractNode) = node(v->log.(v), X)

--- a/src/networks.jl
+++ b/src/networks.jl
@@ -438,6 +438,10 @@ MLJBase.table(X::AbstractNode) = node(MLJBase.table, X)
 Base.vcat(args::AbstractNode...) = node(vcat, args...)
 Base.hcat(args::AbstractNode...) = node(hcat, args...)
 
+Statistics.mean(X::AbstractNode) = node(v->mean.(v), X)
+Statistics.median(X::AbstractNode) = node(v->median.(v), X)
+StatsBase.mode(X::AbstractNode) = node(v->mode.(v), X)
+
 Base.log(X::AbstractNode) = node(v->log.(v), X)
 Base.exp(X::AbstractNode) = node(v->exp.(v), X)
 

--- a/test/networks.jl
+++ b/test/networks.jl
@@ -177,6 +177,19 @@ end
     ys = source(y)
     @test vcat(ys, ys)() == vcat(y, y)
     @test hcat(ys, ys)() == hcat(y, y)
+    @test log(ys)() == log.(y)
+    @test exp(ys)() == exp.(y)
+
+    Z = (rand(4), rand(4), rand(4))
+    Zs = source(Z)
+    @test mean(Zs)() == mean.(Z)
+    @test mode(Zs)() == mode.(Z)
+    @test median(Zs)() == median.(Z)
+
+    a, b, λ = rand(4), rand(4), rand()
+    as, bs = source(a), source(b)
+    @test (as + bs)() == a + b
+    @test (λ * bs)() == λ * b
 end
 
 end


### PR DESCRIPTION
As per #288, `mean`, `median`, and `mode` methods for AbstractNode have been added. I noticed that these functions are no longer in the Base module and have been moved to the stdlib Statistics. 
Tests have also been added! 
