### PR TITLE
Stratified cross-validation

### DIFF
--- a/docs/src/evaluating_model_performance.md
+++ b/docs/src/evaluating_model_performance.md
@@ -86,10 +86,7 @@ Or define their own re-usable `ResamplingStrategy` objects, - see
 [Custom resampling strategies](@ref) below.
 
 
-### Resampling strategies
-
-`Holdout` and `CV` (cross-validation) resampling strategies are
-available:
+### Built-in resampling strategies
 
 
 ```@docs
@@ -98,6 +95,10 @@ Holdout
 
 ```@docs
 CV
+```
+
+```@docs
+StratifiedCV
 ```
 
 

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -8,7 +8,8 @@ export MLJ_VERSION
 export @curve, @pcurve, pretty,                   # utilities.jl
     coerce, supervised, unsupervised,             # tasks.jl
     report,                                       # machines.jl
-    Holdout, CV, evaluate!, Resampler,            # resampling.jl
+    Holdout, CV, StratifiedCV, evaluate!,         # resampling.jl
+    Resampler,                                    # resampling.jl
     Params, params, set_params!,                  # parameters.jl
     strange, iterator,                            # parameters.jl
     Grid, TunedModel, learning_curve!,            # tuning.jl

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -71,6 +71,11 @@ folds A, B and C and the model will be trained three times, first with
 A and B and tested on C, then on A, C and tested on B and finally on
 B, C and tested on A.
 
+In the typical case that `n_folds` does not divide the number of
+observations, the last test is longer than the other tests sets, which
+are all equal in size. The test sets are always mutually exclusive, and
+each train set is always the complement of the corresponding test set.
+
 If `rng` is an integer, then `MersenneTwister(rng)` is the random
 number generator used for shuffling rows. Otherwise some `AbstractRNG`
 object is expected.
@@ -113,11 +118,13 @@ function train_test_pairs(cv::CV, rows)
     # define the (trainrows, testrows) pairs:
     firsts = 1:k:((nfolds - 1)*k + 1) # itr of first `test` rows index
     seconds = k:k:(nfolds*k)          # itr of last  `test` rows index
+
     ret = map(1:nfolds) do k
         f = firsts[k]
         s = seconds[k]
+        k < nfolds || (s = n_observations)
         return (vcat(rows[1:(f - 1)], rows[(s + 1):end]), # trainrows
-                rows[f:s])                               # testrows
+                rows[f:s])                                # testrows
     end
 
     return ret

--- a/src/resampling.jl
+++ b/src/resampling.jl
@@ -9,9 +9,12 @@ function ==(s1::S, s2::S) where S <: ResamplingStrategy
     return all(getfield(s1, fld) == getfield(s2, fld) for fld in fieldnames(S))
 end
 
+# fallbacks:
 train_test_pairs(s::ResamplingStrategy, rows, X, y, w) =
     train_test_pairs(s, rows, X, y)
 train_test_pairs(s::ResamplingStrategy, rows, X, y) =
+    train_test_pairs(s, rows, y)
+train_test_pairs(s::ResamplingStrategy, rows, y) =
     train_test_pairs(s, rows)
 
 """
@@ -137,13 +140,15 @@ function train_test_pairs(cv::CV, rows)
 end
 
 """
-    stratified_cv = StratifiedCV(; nfolds=6,  shuffle=false, rng=Random.GLOBAL_RNG)
+    stratified_cv = StratifiedCV(; nfolds=6,  
+                                   shuffle=false, 
+                                   rng=Random.GLOBAL_RNG)
 
 Stratified cross-validation resampling strategy, for use in
 `evaluate!`, `evaluate` and in tuning. Applies only to classification
 problems (`OrderedFactor` or `Multiclass` targets).
 
-    train_test_pairs(stratified_cv, rows, X, y)        # X is ignored
+    train_test_pairs(stratified_cv, rows, y)
  
 Returns an `nfolds`-length iterator of `(train, test)` pairs of
 vectors (row indices) where each `train` and `test` is a sub-vector of

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -142,7 +142,7 @@ end
                                                 rows, nothing, y)
 
     # check class distribution is preserved in a larger randomized example:
-    N = 3
+    N = 30
     y = shuffle(vcat(fill(:a, N), fill(:b, 2N),
                         fill(:c, 3N), fill(:d, 4N))) |> categorical;
     d = fit(UnivariateFinite, y)
@@ -150,7 +150,7 @@ end
     folds = vcat(first.(pairs), last.(pairs))
     @test all([fit(UnivariateFinite, y[fold]) ≈ d for fold in folds])
 
-    
+
 end
 
 @testset "weights" begin

--- a/test/resampling.jl
+++ b/test/resampling.jl
@@ -118,6 +118,41 @@ end
     @test shuffled.measurement[1] != result.measurement[1]
 end
 
+@testset "stratified_cv" begin
+
+    # check in explicit example:
+    y = categorical(['c', 'a', 'b', 'a', 'c', 'x',
+                 'c', 'a', 'a', 'b', 'b', 'b', 'b', 'b'])
+    rows = [14, 13, 12, 11, 10, 9, 8, 7, 5, 4, 3, 2, 1]
+    @test y[rows] == collect("bbbbbaaccabac")
+    scv = StratifiedCV(nfolds=3)
+    pairs = MLJ.train_test_pairs(scv, rows, nothing, y)
+    @test pairs == [([12, 11, 10, 8, 5, 4, 3, 2, 1], [14, 13, 9, 7]),
+                    ([14, 13, 10, 9, 7, 4, 3, 2, 1], [12, 11, 8, 5]),
+                    ([14, 13, 12, 11, 9, 8, 7, 5], [10, 4, 3, 2, 1])]
+    scv_random = StratifiedCV(nfolds=3, shuffle=true)
+    pairs_random = MLJ.train_test_pairs(scv_random, rows, nothing, y)
+    @test pairs != pairs_random
+
+    # wrong target type throws error:
+    @test_throws Exception MLJ.train_test_pairs(scv, rows, nothing, get.(y))
+
+    # too many folds throws error:
+    @test_throws Exception MLJ.train_test_pairs(StratifiedCV(nfolds=4),
+                                                rows, nothing, y)
+
+    # check class distribution is preserved in a larger randomized example:
+    N = 3
+    y = shuffle(vcat(fill(:a, N), fill(:b, 2N),
+                        fill(:c, 3N), fill(:d, 4N))) |> categorical;
+    d = fit(UnivariateFinite, y)
+    pairs = MLJ.train_test_pairs(scv, 1:10N, nothing, y)
+    folds = vcat(first.(pairs), last.(pairs))
+    @test all([fit(UnivariateFinite, y[fold]) ≈ d for fold in folds])
+
+    
+end
+
 @testset "weights" begin
 
     # cv:


### PR DESCRIPTION
resolves #108 

I have also rewritten the resampling strategy docstrings to make them more technically concise. More "instructional" documentation should go in the manual (a little less concise) and MLJTutorials (the most verbose). 

From the new docstring:

---

    stratified_cv = StratifiedCV(; nfolds=6,  shuffle=false, rng=Random.GLOBAL_RNG)

Stratified cross-validation resampling strategy, for use in
`evaluate!`, `evaluate` and in tuning. Applies only to classification
problems (`OrderedFactor` or `Multiclass` targets).

    train_test_pairs(stratified_cv, rows, X, y)        # X is ignored
 
Returns an `nfolds`-length iterator of `(train, test)` pairs of
vectors (row indices) where each `train` and `test` is a sub-vector of
`rows`. The `test` vectors are mutually exclusive and exhaust
`rows`. Each `train` vector is the complement of the corresponding
`test` vector. 

Unlike regular cross-validation, the distribution of the levels of the
target `y` corresponding to each `train` and `test` is constrained, as
far as possible, to replicate that of `y[rows]` as a whole.

Specifically, the data is split into a number of groups on which `y`
is constant, and each individual group is resampled according to the
ordinary cross-validation strategy `CV(nfolds=nfolds)`. To obtain the
final `(train, test)` pairs of row indices, the per-group pairs are
collated in such a way that each collated `train` and `test` respects
the original order of `rows` (after shuffling, if `shuffle=true`).

If `rng` is an integer, then `MersenneTwister(rng)` is the random
number generator used for shuffling rows. Otherwise some `AbstractRNG`
object is expected.
