### PR TITLE
don't export StaticTransformer

### DIFF
--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -85,9 +85,8 @@ export Grid, RandomSearch, Explicit, TunedModel,
 # re-export from MLJModels:
 export models, localmodels, @load, load, info,
     ConstantRegressor, ConstantClassifier,     # builtins/Constant.jl
-    StaticTransformer, FeatureSelector,        # builtins/Transformers.jl
-    UnivariateStandardizer, Standardizer,
-    UnivariateBoxCoxTransformer,
+    FeatureSelector, UnivariateStandardizer,   # builtins/Transformers.jl
+    Standardizer, UnivariateBoxCoxTransformer,
     OneHotEncoder, ContinuousEncoder, UnivariateDiscretizer,
     FillImputer
 


### PR DESCRIPTION
it turns out that we don't want to reexport this. See https://github.com/alan-turing-institute/MLJBase.jl/pull/279#issuecomment-623189385