### PR TITLE
Create the "PullRequestBaseBranch" GitHub Action

### DIFF
--- a/.github/workflows/PullRequestBaseBranch.yml
+++ b/.github/workflows/PullRequestBaseBranch.yml
@@ -1,0 +1,11 @@
+name: PullRequestBaseBranch
+on:
+  pull_request:
+    types: [closed, edited, locked, opened, ready_for_review, reopened, synchronize, unlocked]
+jobs:
+  PullRequestBaseBranch:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The base branch is ${{ github.base_ref }}."
+      - if: github.base_ref == 'master'
+        run: echo "ERROR. The base branch is master. Please open your pull request against the dev branch instead." && exit 1


### PR DESCRIPTION
On more than one occasion, I have opened a pull request against `master` when I should I have opened it against `dev`.

This PR adds the `PullRequestBaseBranch` GitHub Action. This GitHub Action will fail if the base branch is `master` and will pass otherwise.