### PR TITLE
removed type piracy of show for MersenneTwister

### DIFF
--- a/src/ensembles.jl
+++ b/src/ensembles.jl
@@ -1,8 +1,3 @@
-# shorter display of MersenneTwister:
-Base.show(stream::IO, t::Random.MersenneTwister) =
-    print(stream, "MersenneTwister($(t.seed)) @ $(t.idxF)")
-
-
 ## ENSEMBLES OF FITRESULTS
 
 # Atom is atomic model type, eg, DecisionTree


### PR DESCRIPTION
The definition of `show` here is not only type piracy, but it overwrites the exact same method in `Random` which can cause pre-compilation to be broken in some circumstances.  The compiler throws a warning about this if one import MLJ after explicitly importing `Random`.

My vote would be to simply go along with the `show` method in `Random`, as it's really not that long
```julia
# julia 1.6-dev
MersenneTwister(1234, (0, 1002, 0, 3))
```
Regardless, this redundant method should definitely be removed.
