### PR TITLE
use `add` instead of `develop` when recommending old OpenSpecFun_jll

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ appropriate version, activate your MLJ environment and run
 
 ```julia
   using Pkg;
-  Pkg.develop(PackageSpec(url="https://github.com/tlienart/OpenSpecFun_jll.jl"))
+  Pkg.add(PackageSpec(url="https://github.com/tlienart/OpenSpecFun_jll.jl"))
 ```
 
 #### Serialization for composite models with component models with custom serialization


### PR DESCRIPTION
I don't see any need for a `develop` call here. You just want to install a package from a URL.