### PR TITLE
Update openml_integration.md

### DIFF
--- a/docs/src/openml_integration.md
+++ b/docs/src/openml_integration.md
@@ -9,7 +9,7 @@ MLJ with OpenML is a work in progress.
 
 As an example, we will try to load the iris dataset using `OpenML.load(taskID)`.
 
-```@example OpenML
+```@setup OpenML
 using MLJ.MLJBase
 ```
 


### PR DESCRIPTION
The current documentation of the MLJ and OpenML integration available at https://alan-turing-institute.github.io/MLJ.jl/stable/openml_integration/#Task-ID-1 is showing some errors(Refer the attached screenshot)

![image](https://user-images.githubusercontent.com/49980787/113469545-f3586480-946b-11eb-9ee3-32da0abd5eca.png)

 
This PR fixes that by adding an ```@setup``` macro at the top of the 1st block.