### PR TITLE
Update linguist to better reflect the source language of the package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*ipynb linguist-vendored


### PR DESCRIPTION
The package is written in pure Julia. However, the repo also includes many examples in the form of jupyter-notebooks, which is incorrectly calculated by GitHub linguist as the repo having a major portion written in the form of *.ipynb files, which is incorrect.

This is just me being pedantic but it would be a nice addition to correct this calculation. This PR aims to solve this issue.