### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/src/adding_models_for_general_use.md
+++ b/docs/src/adding_models_for_general_use.md
@@ -1208,7 +1208,7 @@ UnivariateFinite
 
 ```@docs
 MLJBase.recursive_getproperty
-MLJBase.recurseive_setproperty!
+MLJBase.recursive_setproperty!
 ```
 
 


### PR DESCRIPTION
Was visible in the docs build log:
```
┌ Warning: undefined binding 'MLJBase.recurseive_setproperty!' in `@docs` block in src/adding_models_for_general_use.md:1209-1212
│ ```@docs
│ MLJBase.recursive_getproperty
│ MLJBase.recurseive_setproperty!
│ ```
└ @ Documenter.Expanders ~/.julia/packages/Documenter/R2HVS/src/Expanders.jl:300
```