### PR TITLE
Document the `Explicit` tuning strategy

### DIFF
--- a/docs/src/tuning_models.md
+++ b/docs/src/tuning_models.md
@@ -267,8 +267,7 @@ mach = machine(self_tuning_forest, X, y);
 fit!(mach, verbosity=0);
 ```
 
-We can plot the grid search results is also
-available:
+We can plot the grid search results:
 
 ```julia
 using Plots
@@ -294,10 +293,40 @@ self_tuning_forest = TunedModel(model=forest,
                                       measure=rms,
                                       n=25);
 fit!(machine(self_tuning_forest, X, y), verbosity=0);
+
+history = report(mach).history
+scores = [entry.measurement[1] for entry in history]
 ```
 
 For more options for a grid search, see [`Grid`](@ref) below.
 
+## Tuning multiple models
+
+We can also compare multiple models via the tuning strategy. This
+can, for example, be used to run _nested cross-validation_. In summary,
+normal (k-fold) cross-validation would check one or more models and
+split the data into `k` folds. Nested cross-validation, first, splits
+the data in multiple train and test sets and, then, runs
+cross-validation for each model in order to reduce bias. To do this in
+MLJ, we use a `TunedModel`:
+
+```@example goof
+using NearestNeighborModels
+
+models = [
+    KNNClassifier(K=2),
+    KNNClassifier(K=10),
+    ConstantClassifier()
+]
+tuning = Holdout(; fraction_train=0.6)
+resampling = CV(; nfolds=6)
+measure = LogLoss()
+n = 25
+
+tmodel = TunedModel(; models, tuning, resampling, measure, n)
+mach = machine(tmodel, X, y)
+fit!(mach; verbosity=0)
+```
 
 ## Tuning using a random search
 

--- a/docs/src/tuning_models.md
+++ b/docs/src/tuning_models.md
@@ -293,9 +293,6 @@ self_tuning_forest = TunedModel(model=forest,
                                       measure=rms,
                                       n=25);
 fit!(machine(self_tuning_forest, X, y), verbosity=0);
-
-history = report(mach).history
-scores = [entry.measurement[1] for entry in history]
 ```
 
 For more options for a grid search, see [`Grid`](@ref) below.
@@ -326,6 +323,9 @@ n = 25
 tmodel = TunedModel(; models, tuning, resampling, measure, n)
 mach = machine(tmodel, X, y)
 fit!(mach; verbosity=0)
+
+history = report(mach).history
+scores = [entry.measurement[1] for entry in history]
 ```
 
 ## Tuning using a random search

--- a/docs/src/tuning_models.md
+++ b/docs/src/tuning_models.md
@@ -310,8 +310,12 @@ MLJ, we use a `TunedModel`:
 ```@example goof
 tree = (@load DecisionTreeClassifier pkg=DecisionTree verbosity=0)()
 knn = (@load KNNClassifier pkg=NearestNeighborModels verbosity=0)()
+nothing # hide
+```
 
-# model equivalent to best in `models` using 3-fold CV:
+This model is equivalent to best in `models` by using 3-fold cross-validation:
+
+```@example goof
 blended = TunedModel(models=[tree, knn],
                      resampling=CV(nfolds=3),
                      measure=log_loss,


### PR DESCRIPTION
In response to #822.

@ablaom, In this PR, I've tried to add an example for nested cross-validation as discussed before. You said it could be done now since https://github.com/JuliaAI/MLJTuning.jl/pull/142. However, I cannot figure out how to do it. I would expect this PR to work, but instead I get:

```
c.value = ArgumentError: You have specified an explicit iterator `models` of MLJModels and so cannot specify any `tuning` strategy except `Explicit`. Either omit the `tuning=...` specification, or specify a *single* model using `model=...` instead.
```