### PR TITLE
Fix MLJFlux.jl project URL

### DIFF
--- a/ORGANIZATION.md
+++ b/ORGANIZATION.md
@@ -74,7 +74,7 @@ its conventional use, are marked with a ⟂ symbol:
   such as Lasso, Elastic-Net, Robust regression, LAD regression,
   etc. 
 
-* [MLJFlux.jl](https://github.com/JuliaAI/MLJFlux.jl) an experimental
+* [MLJFlux.jl](https://github.com/FluxML/MLJFlux.jl) an experimental
   package for gradient-descent models, such as traditional
   neural-networks, built with
   [Flux.jl](https://github.com/FluxML/Flux.jl), in MLJ.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,7 +42,7 @@ list](https://github.com/alan-turing-institute/MLJ.jl/issues/673).
 
 ### Adding models
 
-- [ ] **Integrate deep learning** using [Flux.jl](https://github.com/FluxML/Flux.jl.git) deep learning.  [Done](https://github.com/JuliaAI/MLJFlux.jl) but can
+- [ ] **Integrate deep learning** using [Flux.jl](https://github.com/FluxML/Flux.jl.git) deep learning.  [Done](https://github.com/FluxML/MLJFlux.jl) but can
   improve experience by:
 
   - [x] finishing iterative model wrapper [#139](https://github.com/alan-turing-institute/MLJ.jl/issues/139)

--- a/docs/src/list_of_supported_models.md
+++ b/docs/src/list_of_supported_models.md
@@ -25,7 +25,7 @@ models()`.
 [GLM.jl](https://github.com/JuliaStats/GLM.jl) | LinearRegressor, LinearBinaryClassifier, LinearCountRegressor | medium | †
 [LIBSVM.jl](https://github.com/mpastell/LIBSVM.jl) | LinearSVC, SVC, NuSVC, NuSVR, EpsilonSVR, OneClassSVM | high | also via ScikitLearn.jl
 [LightGBM.jl](https://github.com/IQVIA-ML/LightGBM.jl) | LightGBMClassifier, LightGBMRegressor | high | 
-[MLJFlux.jl](https://github.com/JuliaAI/MLJFlux.jl) | NeuralNetworkRegressor, NeuralNetworkClassifier, MultitargetNeuralNetworkRegressor, ImageClassifier | experimental |
+[MLJFlux.jl](https://github.com/FluxML/MLJFlux.jl) | NeuralNetworkRegressor, NeuralNetworkClassifier, MultitargetNeuralNetworkRegressor, ImageClassifier | experimental |
 [MLJLinearModels.jl](https://github.com/JuliaAI/MLJLinearModels.jl) | LinearRegressor, RidgeRegressor, LassoRegressor, ElasticNetRegressor, QuantileRegressor, HuberRegressor, RobustRegressor, LADRegressor, LogisticClassifier, MultinomialClassifier | experimental |
 [MLJModels.jl](https://github.com/JuliaAI/MLJModels.jl) (built-in) | StaticTransformer, FeatureSelector, FillImputer, UnivariateStandardizer, Standardizer, UnivariateBoxCoxTransformer, OneHotEncoder, ContinuousEncoder, ConstantRegressor, ConstantClassifier, BinaryThreshholdPredictor | medium |
 [MLJText.jl](https://github.com/JuliaAI/MLJText.jl) | TfidfTransformer, BM25Transformer, BagOfWordsTransformer | low |


### PR DESCRIPTION
I found links for MLJFlux.j are broken in some documents.
This PR fixed these broken URLs in the following way.

OLD: https://github.com/JuliaAI/MLJFlux.jl
NEW: https://github.com/FluxML/MLJFlux.jl

