### PR TITLE
(re) updated model names of BetaML

### DIFF
--- a/docs/src/list_of_supported_models.md
+++ b/docs/src/list_of_supported_models.md
@@ -27,7 +27,7 @@ independent assessment.
 
 | Package | Interface Pkg | Models | Maturity | Note
 | ------- | ------------- | ------ | -------- | ----
-[BetaML.jl](https://github.com/sylvaticus/BetaML.jl) | - | BetaMLGMMImputer, BetaMLGMMRegressor, BetaMLGenericImputer, BetaMLMeanImputer, BetaMLRFImputer, DecisionTreeClassifier, DecisionTreeRegressor, GMMClusterer, KMeans, KMedoids, KernelPerceptronClassifier, MissingImputator, PegasosClassifier, PerceptronClassifier, RandomForestClassifier, RandomForestRegressor | medium |
+[BetaML.jl](https://github.com/sylvaticus/BetaML.jl) | - | DecisionTreeClassifier, RandomForestClassifier, NeuralNetworkClassifier, LinearPerceptron, KernelPerceptron, Pegasos, DecisionTreeRegressor, RandomForestRegressor, NeuralNetworkRegressor, MultitargetNeuralNetworkRegressor, GaussianMixtureRegressor, MultitargetGaussianMixtureRegressor, KMeans, KMedoids, GaussianMixtureClusterer,  SimpleImputer,  GaussianMixtureImputer, RandomForestImputer, GeneralImputer | medium |
 [Clustering.jl](https://github.com/JuliaStats/Clustering.jl) | [MLJClusteringInterface.jl](https://github.com/JuliaAI/MLJClusteringInterface.jl) | KMeans, KMedoids | high | †
 [DecisionTree.jl](https://github.com/bensadeghi/DecisionTree.jl) | [MLJDecisionTreeInterface.jl](https://github.com/JuliaAI/MLJDecisionTreeInterface.jl) | DecisionTreeClassifier, DecisionTreeRegressor, AdaBoostStumpClassifier, RandomForestClassifier, RandomForestRegressor | high | 
 [EvoTrees.jl](https://github.com/Evovest/EvoTrees.jl) | - | EvoTreeRegressor, EvoTreeClassifier, EvoTreeCount, EvoTreeGaussian, EvoTreeMLE | medium | tree-based gradient boosting models


### PR DESCRIPTION
For some reason the precedent PR was not accounted for. This PR (based on dev) try again to update the names of BetaML models. From https://github.com/alan-turing-institute/MLJ.jl/issues/993 (reordered).