### PR TITLE
Exclude `bib`, `md`, and `drawio` from repo stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *ipynb linguist-vendored
 *.bib linguist-vendored
+*.md linguist-vendored
+*.drawio linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *ipynb linguist-vendored
+*.bib linguist-vendored


### PR DESCRIPTION
Currently, Linguist shows that the repository is 50.1% TeX meaning that the repo will be classified as a TeX repo. This PR sets `linguist-vendored` for some more files to exclude them from the stats (see [github/linguist/overrides.md](https://github.com/github/linguist/blob/master/docs/overrides.md) for more information).

In my own fork (https://github.com/rikhuijzer/MLJ.jl), this change makes the repo appear as 100% Julia.