### PR TITLE
Remove CatBoost.jl from third party packages

### DIFF
--- a/docs/src/third_party_packages.md
+++ b/docs/src/third_party_packages.md
@@ -15,7 +15,6 @@ See [List of Supported Models](@ref model_list)
 
 ## Providing unregistered models:
 
-- [CatBoost.jl](https://github.com/JuliaAI/CatBoost.jl)
 - [SossMLJ.jl](https://github.com/cscherrer/SossMLJ.jl)
 - [TimeSeriesClassification](https://github.com/alan-turing-institute/TimeSeriesClassification.jl)
 


### PR DESCRIPTION
CatBoost.jl is in the list of supported models and the list of third-party unregistered models