### PR TITLE
Adding necessary exports

### DIFF
--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -92,7 +92,7 @@ export nrows, color_off, color_on,
     @load_boston, @load_ames, @load_iris, @load_reduced_ames, @load_crabs,
     load_boston, load_ames, load_iris, load_reduced_ames, load_crabs,
     Machine, machine, AbstractNode, @node,
-
+    source, node, fit!, freeze!, thaw!, Node, sources, origins,
     machines, sources, anonymize!, @from_network, fitresults,
     @pipeline, Stack, Pipeline, TransformedTargetModel,
     ResamplingStrategy, Holdout, CV, TimeSeriesCV,


### PR DESCRIPTION
Solving #1041 by importing `fit!` and others again. In #1034, that functions were removed probably by accident.