### PR TITLE
CI: fix the YAML syntax for the docs job, and thus properly surface any docbuild failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
            else
                build_docs = false
            end
-           build_docs = true # TODO: delete this debugging line
            if build_docs
                @info("We will build the docs")
                set_environment_variable("BUILD_DOCS", "true")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,20 +81,21 @@ jobs:
                set_environment_variable("BUILD_DOCS", "false")
            end'
       - run: |
-          julia --project=docs -e '
-            if ENV["BUILD_DOCS"] == "true"
-                using Pkg
-                Pkg.develop(PackageSpec(path=pwd()))
-                Pkg.instantiate()
-            end'
-      - run: julia --project=docs -e '
-            if ENV["BUILD_DOCS"] == "true"
-                @info "attempting to build the docs"
-                run(`julia --project=docs docs/make.jl`)
-                @info "successfully built the docs"
-            else
-                @info "skipping the docs build"
-            end'
+          if ENV["BUILD_DOCS"] == "true"
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()
+          end
+        shell: julia --color=yes --project=docs {0}
+      - run: |
+          if ENV["BUILD_DOCS"] == "true"
+            @info "attempting to build the docs"
+            run(`julia --project=docs docs/make.jl`)
+            @info "successfully built the docs"
+          else
+            @info "skipping the docs build"
+          end
+        shell: julia --color=yes --project=docs {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,14 +81,14 @@ jobs:
                set_environment_variable("BUILD_DOCS", "false")
            end'
       - run: |
-          if ENV["BUILD_DOCS"] != "true"
+          if ENV["BUILD_DOCS"] == "true"
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()
           end
         shell: julia --color=yes --project=docs {0}
       - run: |
-          if ENV["BUILD_DOCS"] != "true"
+          if ENV["BUILD_DOCS"] == "true"
             @info "attempting to build the docs"
             run(`julia --project=docs docs/make.jl`)
             @info "successfully built the docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
            else
                build_docs = false
            end
+           build_docs = true # TODO: delete this debugging line
            if build_docs
                @info("We will build the docs")
                set_environment_variable("BUILD_DOCS", "true")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           end
         shell: julia --color=yes --project=docs {0}
       - run: |
-          if ENV["BUILD_DOCS"] == "true"
+          if ENV["BUILD_DOCS"] != "true"
             @info "attempting to build the docs"
             run(`julia --project=docs docs/make.jl`)
             @info "successfully built the docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
                set_environment_variable("BUILD_DOCS", "false")
            end'
       - run: |
-          if ENV["BUILD_DOCS"] == "true"
+          if ENV["BUILD_DOCS"] != "true"
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()


### PR DESCRIPTION
Fixes the "silent" part of #1045 

Obviously doesn't actually fix the underlying doc failure.