### PR TITLE
Try again to generate the documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -126,5 +126,5 @@ ENV["TRAVIS_PULL_REQUEST"] = "false"
 
 deploydocs(
     repo = "github.com/alan-turing-institute/MLJ.jl.git",
-    push_preview=true
+    push_preview=false
 )


### PR DESCRIPTION
Removed push_preview as distracting.

Now we see in the log that the build is successful but nothing gets deployed on gh-pages, confirmed by looking at date on dev folder here: https://github.com/alan-turing-institute/MLJ.jl/tree/gh-pages (5 months ago).

I don't understand why the docs are not deploying.

@DilumAluthge 