### PR TITLE
Update getting_started.md to avoid error from line 338

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -335,7 +335,7 @@ scientific type `Table{K}`, where `K` depends on the scientific types of the col
 which can be individually inspected using `schema`:
 
 ```@repl doda
-ScientificTypes.schema
+schema(X)
 ```
 
 #### Matrix data


### PR DESCRIPTION
When the command ScientificTypes.schema
is called in line 338 produce an error message
ERROR: UndefVarError: `ScientificTypes` not defined.

My suggestion is replacing line 338 by:
schema(X)