### PR TITLE
Add MLJWrappers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
+      interval: "monthly"
+  - package-ecosystem: "julia"
+    directories: # Location of Julia projects
+      - "/"
+      - "/docs"
+    schedule:
       interval: "weekly"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MLJ"
 uuid = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJ"
 uuid = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
-authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 version = "0.23.0"
+authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
@@ -17,6 +17,7 @@ MLJIteration = "614be32b-d00c-4edb-bd02-1eb411ab5e55"
 MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 MLJTransforms = "23777cdb-d90c-4eb0-a694-7c2b83d5c1d6"
 MLJTuning = "03970b2e-30c4-11ea-3135-d1576263f10f"
+MLJWrappers = "b5d0f7f3-9870-4c70-ba08-cb780c37e63f"
 OpenML = "8b6db2d4-7670-4922-a472-f9537c81ab66"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
@@ -41,6 +42,7 @@ MLJModels = "0.18"
 MLJTestIntegration = "0.5.0"
 MLJTransforms = "0.1.1"
 MLJTuning = "0.8"
+MLJWrappers = "0.1"
 OpenML = "0.2,0.3"
 Pkg = "<0.0.1, 1"
 ProgressMeter = "1.1"

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -3,7 +3,7 @@
 
 [`MLJ`](https://juliaai.github.io/MLJ.jl//dev/) is a Machine Learning toolbox for
 Julia. It collects together functionality from separate components listed below, which can
-be loaded individually. 
+be loaded individually.
 
 Actual model code (e.g., code for instantiating a `DecisionTreeClassifier`) must generally
 be loaded explicitly from the model-providing package, using `@load`, for example. However
@@ -41,6 +41,10 @@ core model wrappers and some common transformers are immediately available; do
 - FeatureSelection.jl: Transformers for feature selection, and the supervised model wrapper
   `RecursiveFeatureSelection`.
 
+- MLJWrappers.jl: Provides the lightweight `Transformer` wrapper for supervised models
+  intended as transformers in model pipelines (e.g., instances of
+  `RecursiveFeatureElimination`).
+
 - OpenML.jl: Tool for grabbing datasets from OpenML.org
 
 """
@@ -63,6 +67,7 @@ using MLJEnsembles
 using MLJTuning
 using MLJModels
 @reexport using FeatureSelection
+@reexport using MLJWrappers
 using OpenML
 @reexport using StatisticalMeasures
 import MLJBalancing

--- a/test/exported_names.jl
+++ b/test/exported_names.jl
@@ -43,4 +43,8 @@ rms
 l2
 log_score
 
+# MLJWrappers
+
+@test Transformer isa Unsupervised
+
 true

--- a/test/exported_names.jl
+++ b/test/exported_names.jl
@@ -45,6 +45,6 @@ log_score
 
 # MLJWrappers
 
-@test Transformer isa Unsupervised
+@test Transformer <: Unsupervised
 
 true


### PR DESCRIPTION
This PR add MLJWrappers as a dep and re-exports its methods, which at the moment is just `Transformer`. 