### PR TITLE
Re-export `describe` from DataAPI.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MLJ"
 uuid = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
-version = "0.23.1"
+version = "0.23.2"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 ComputationalResources = "ed09eef8-17a6-5b46-8889-db040fac31e3"
+DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FeatureSelection = "33837fe5-dbff-4c9e-8c2f-c5612fe2b8b6"
@@ -32,6 +33,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 CategoricalArrays = "1"
 ComputationalResources = "0.3"
+DataAPI = "1.16"
 Distributions = "0.21,0.22,0.23, 0.24, 0.25"
 FeatureSelection = "0.2"
 MLJBalancing = "0.1"

--- a/docs/src/evaluating_model_performance.md
+++ b/docs/src/evaluating_model_performance.md
@@ -5,12 +5,8 @@ selected losses or scores, using the [`evaluate`](@ref) or [`evaluate!`](@ref) m
 For more on available performance measures, see [Performance
 Measures](performance_measures.md).
 
-In addition to hold-out and cross-validation, the user can specify
-an explicit list of train/test pairs of row indices for resampling, or
-define new resampling strategies.
-
-For simultaneously evaluating *multiple* models, see "[Comparing models of different type
-and nested cross-validation](@ref explicit)".
+In addition to hold-out and cross-validation, the user can specify an explicit list of
+train/test pairs of row indices for resampling, or define new resampling strategies.
 
 For externally logging the outcomes of performance evaluation experiments, see [Logging
 Workflows](@ref)
@@ -62,7 +58,7 @@ performance_evaluation = evaluate(
 ## Multiple models
 
 To create a short named tuple summary of a performance evaluation, one can apply the
-`describe` method:
+[`describe`](@ref) method:
 
 ```@repl evaluation_of_supervised_models
 describe(performance_evaluation)
@@ -84,9 +80,14 @@ table = describe.(performance_evaluations);
 pretty(table)
 ```
 
+One can also wrap a collection of models as a single "metamodel", which always represents
+the model with the best performance evaluation estimate for the data it is trained. See
+"[Comparing models of different type and nested cross-validation](@ref explicit)".
+
+
 !!! info
 
-    The `describe` method assumes you have at least MLJBase 1.13.0 installed.
+    The [`describe`](@ref) method assumes you have at least MLJBase 1.13.0 installed.
 	
 
 ## Specifying weights
@@ -196,5 +197,6 @@ MLJBase.evaluate!
 MLJBase.evaluate
 MLJBase.PerformanceEvaluation
 MLJBase.CompactPerformanceEvaluation
+describe
 default_logger
 ```

--- a/docs/src/evaluating_model_performance.md
+++ b/docs/src/evaluating_model_performance.md
@@ -48,8 +48,8 @@ machine potentially change. )
 Multiple measures are specified as a vector:
 
 ```@repl evaluation_of_supervised_models
-evaluate!(
-    mach,
+performance_evaluation = evaluate(
+    model, X, y;
     resampling=cv,
     measures=[l1, rms, rmslp1],
     verbosity=0,
@@ -57,6 +57,37 @@ evaluate!(
 ```
 
 [Custom measures](@ref) can also be provided.
+
+
+## Multiple models
+
+To create a short named tuple summary of a performance evaluation, one can apply the
+`describe` method:
+
+```@repl evaluation_of_supervised_models
+describe(performance_evaluation)
+```
+
+This is useful when tabulating performance evaluations for multiple models, which you can
+do by providing a vector of models in place of `model` in your `evaluate` command. The
+models can also include tags to appear in the final table, as shown in the following
+example:
+
+```@repl evaluation_of_supervised_models
+performance_evaluations = evaluate(
+    ["const" => ConstantRegressor(), "ridge" => model], X, y;
+    resampling=cv,
+    measures=[l1, rms, rmslp1],
+    verbosity=0,
+)
+table = describe.(performance_evaluations);
+pretty(table)
+```
+
+!!! info
+
+    The `describe` method assumes you have at least MLJBase 1.13.0 installed.
+	
 
 ## Specifying weights
 

--- a/src/MLJ.jl
+++ b/src/MLJ.jl
@@ -84,6 +84,7 @@ import Random: AbstractRNG, MersenneTwister
 using ProgressMeter
 using ComputationalResources
 using ComputationalResources: CPUProcesses
+@reexport import DataAPI.describe # extended by MLJBase >= 1.13.0
 
 # to be extended:
 import MLJBase: fit, update, clean!, fit!, predict, fitted_params,

--- a/test/exported_names.jl
+++ b/test/exported_names.jl
@@ -47,4 +47,8 @@ log_score
 
 @test Transformer <: Unsupervised
 
+# DataAPI
+
+describe
+
 true


### PR DESCRIPTION
This supports the extension of `describe` by MLJBase 1.13.0 described here: https://github.com/JuliaAI/MLJBase.jl/pull/1045.